### PR TITLE
Remove unsent queing

### DIFF
--- a/satcom-modem-interface/messagelog.cpp
+++ b/satcom-modem-interface/messagelog.cpp
@@ -16,230 +16,35 @@ MessageLog::MessageLog(const char* filename, int sdChipSelectPin, int sdCardDete
   }
 }
 
-// Wrapper for SDLib::File::read() which operates atomically on a File as well
-// as implements an activity LED
-bool MessageLog::read(uint32_t position, char *x) {
-  ledOn();
-  bool readStatus = false;
-  File file = SD.open(this->filename, FILE_READ);
-  if (file) {
-    file.seek(position);
-    int y = file.read();
-    if (y != -1) {
-      readStatus = true;
-      *x = y;
-    }
-  }
-  file.close();
-  ledOff();
-  return readStatus;
-}
-
-// Wrapper for SDLib::File::write() which operates atomically on a File as well
-// as implements an activity LED. Returns number of bytes written.
-size_t MessageLog::write(uint8_t c) {
-  ledOn();
-  File file = SD.open(this->filename, FILE_WRITE);
+// Wrapper for SDLib::File::println() which implements an activity LED.
+// Returns number of bytes written.
+int MessageLog::append(String *message) {
   size_t s = 0;
+  ledOn();
+
+  // Check SD card status before proceding
+  if (digitalRead(this->sdCardDetectPin) == LOW) {
+    MESSAGELOG_PRINTLN(F("SD card not inserted."));
+    ledOff();
+    return s;
+  }
+  if (!SD.begin(this->sdChipSelectPin)) {
+    MESSAGELOG_PRINTLN(F("Error initializing SD card interface."));
+    ledOff();
+    return s;
+  }
+
+  File file = SD.open(this->filename, FILE_WRITE);
   if (!file) {
     MESSAGELOG_PRINTLN("Unable to open " + this->filename + " with mode FILE_WRITE");
     ledOff();
     return s;
   }
-  s = file.write(c);
+  message->trim();
+  s = file.println(*message);
   file.close();
   ledOff();
   return s;
-}
-
-// Wrapper for SDLib::File::size()
-size_t MessageLog::size() {
-  ledOn();
-  size_t s = 0;
-  File file = SD.open(this->filename, FILE_READ);
-  if (file) {
-    s = file.size();
-  }
-  file.close();
-  ledOff();
-  return s;
-}
-
-// normalize ensures the underlying file is properly formatted and is idempotent
-int MessageLog::normalize() {
-  // Ensure newline is at end of file
-  int s = size();
-  if (s == 0) {
-    if (write('\n') != 1) {
-      MESSAGELOG_PRINTLN("Error adding newline to " + this->filename);
-      return -1;
-    }
-    return 0;
-  }
-  char c;
-  if (!read(size() - 1, &c)) {
-    MESSAGELOG_PRINTLN("Error initializing " + this->filename);
-    return -1;
-  }
-  if (c != '\n') {
-    if (write('\n') != 1) {
-      MESSAGELOG_PRINTLN("Error adding newline to " + this->filename);
-      return -1;
-    }
-  }
-  return 0;
-}
-
-// Dump contents of this->filename to Serial
-void MessageLog::dumpToSerial() {
-  normalize();
-  Serial.println(F("----------"));
-  size_t s = size();
-  char c;
-  for (size_t i = 0; i < s; i++) {
-    read(i, &c);
-    Serial.print(c);
-  }
-  Serial.println(F("----------"));
-}
-
-// push places a String on the stack
-int MessageLog::push(String *message) {
-  if (normalize() == -1) {
-    return -1;
-  }
-  message->trim();
-  // Make sure message is terminated with a newline
-  message->concat('\n');
-  for (size_t i = 0; i < message->length(); i++) {
-    if (write(message->charAt(i)) != sizeof(message->charAt(i))) {
-      MESSAGELOG_PRINTLN(F("push write() failed"));
-      return -1;
-    }
-  }
-  return 0;
-}
-
-// pop removes and returns the most recent String on the stack
-void MessageLog::pop(String *message) {
-  *message = "";
-  normalize();
-  // The majority of this method is a workaround for the fact that some versions
-  // of the SD library don't support having multiple files open at once.
-  size_t s = size();
-  // Find penultimate newline and note position
-  if (s == 0) {
-    return;
-  }
-  int penultimateNewline = -1, curNewline = -1;
-  char c;
-  for (size_t i = 0; i < s; i++) {
-    if (!read(i, &c)) {
-      MESSAGELOG_PRINTLN("cannot read " + this->filename);
-      return;
-    }
-    if (c == '\n') {
-      penultimateNewline = curNewline;
-      curNewline = i;
-    }
-  }
-
-  if (curNewline == -1) {
-    MESSAGELOG_PRINTLN(F("pop() no newlines found"));
-    return;
-  }
-
-  // Get last line
-  for (size_t i = penultimateNewline; i < s; i++) {
-    if (!read(i, &c)) {
-      MESSAGELOG_PRINTLN(F("pop() cannot find last line"));
-      *message = "";
-      return;
-    }
-    message->concat(c);
-  }
-
-  // CopyBytes from 0 to the second to last newline position to temp file
-  char tempFilename[16] = {0};
-  snprintf(tempFilename, sizeof(tempFilename), "%d.txt", (uint16_t)millis());
-
-  // Delete and recreate the temp file first in case it already exists
-  SD.remove(tempFilename);
-  File temp = SD.open(tempFilename, (O_READ | O_WRITE | O_CREAT));
-  temp.close();
-
-  // Copy everything to the temp file
-  for (size_t i = 0; i < s; i++) {
-    if (!read(i, &c)) {
-      *message = "";
-      MESSAGELOG_PRINTLN(F("pop() cannot read #2"));
-      return;
-    }
-    File temp = SD.open(tempFilename, FILE_WRITE);
-    if (!temp) {
-      MESSAGELOG_PRINTLN(F("Unable to create temp file"));
-      MESSAGELOG_PRINTLN(tempFilename);
-      *message = "";
-      return;
-    }
-    if (temp.write(c) != 1) {
-      MESSAGELOG_PRINTLN(F("Error writing to temp file"));
-      MESSAGELOG_PRINTLN(tempFilename);
-      temp.close();
-      *message = "";
-      return;
-    }
-    temp.close();
-  }
-  // Write everything except the last line back to this->filename
-  SD.remove(this->filename);
-  for (int i = 0; i < penultimateNewline + 1; i++) {
-    File temp = SD.open(tempFilename, FILE_READ);
-    if (!temp) {
-      MESSAGELOG_PRINTLN(F("Unable to open temp file"));
-      MESSAGELOG_PRINTLN(tempFilename);
-      *message = "";
-      return;
-    }
-    temp.seek(i);
-    int c = temp.read();
-    if (c == -1) {
-      MESSAGELOG_PRINTLN(F("Error reading from temp file"));
-      MESSAGELOG_PRINTLN(tempFilename);
-      temp.close();
-      *message = "";
-      return;
-    }
-    write((char)c);
-    temp.close();
-  }
-
-  // Delete temp file
-  SD.remove(tempFilename);
-  // Return line
-  message->trim();
-}
-
-// numMessages returns the number of messages in the stack
-int MessageLog::numMessages() {
-  size_t s = size();
-  int num = 0;
-  // start with i = 1 since an "empty" normalized file will still have a
-  // newline as the 0th character
-  if (s < 2) {
-    return 0;
-  }
-  char c;
-  for (size_t i = 1; i < s; i++) {
-    if (!read(i, &c)) {
-      MESSAGELOG_PRINTLN("numMessages(): error reading from " + this->filename + " at " + i + " length " + s);
-      return -1;
-    }
-    if (c == '\n') {
-      num++;
-    }
-  }
-  return num;
 }
 
 // ledOn sets the led pin high

--- a/satcom-modem-interface/messagelog.h
+++ b/satcom-modem-interface/messagelog.h
@@ -11,24 +11,21 @@
 #ifndef _MESSAGELOG_H
 #define _MESSAGELOG_H
 
+#define SDCardCSPin 4
+#define SDCardDetectPin 7
+#define SDCardActivityLEDPin (SDCARD_ENABLE_LED ? 8 : -1)
+
 // MessageLog implements a LIFO stack with a file on an SD card
 class MessageLog {
   public:
     MessageLog(const char *filename, int sdChipSelectPin, int sdCardDetectPin, int activityLEDPin);
-    int push(String *newMessage);
-    void pop(String *message);
-    int numMessages();
+    int append(String *newMessage);
     void dumpToSerial();
   private:
     String filename;
     int sdChipSelectPin, sdCardDetectPin, activityLEDPin;
     void ledOn();
     void ledOff();
-    unsigned int copyBytes(const char *sourceFilename, const char *destFilename, unsigned int start, unsigned int count);
-    size_t write(uint8_t);
-    bool read(uint32_t position, char *x);
-    size_t size();
-    int normalize();
 };
 
 #endif

--- a/satcom-modem-interface/satcom-modem-interface.ino
+++ b/satcom-modem-interface/satcom-modem-interface.ino
@@ -10,7 +10,6 @@
 #define SDCardCSPin 4
 #define SDCardDetectPin 7
 #define SDCardActivityLEDPin (SDCARD_ENABLE_LED ? 8 : -1)
-MessageLog unsentMessageLog("unsent.txt", SDCardCSPin, SDCardDetectPin, SDCardActivityLEDPin);
 MessageLog sentMessageLog("sent.txt", SDCardCSPin, SDCardDetectPin, SDCardActivityLEDPin);
 
 #define IridiumSerial Serial1
@@ -115,7 +114,6 @@ void setup()
 void loop()
 {
   messageCheck();
-  sendMessages();
   sleepCheck();
   checkLEDBlink();
 }
@@ -128,57 +126,43 @@ void messageCheck() {
       Serial.println(F("Error reading message from RelaySerial."));
       continue;
     }
-    if (unsentMessageLog.push(&message) != 0) {
-      Serial.println(F("Error from unsentMessageLog.push()"));
+    if (sentMessageLog.push(&message) != 0) {
+      Serial.println(F("Error from sentMessageLog.push()"));
     }
+    sendMessage(&message);
   }
 }
 
-void sendMessages() {
+void sendMessage(String *message) {
   // wake up iridium modem
   digitalWrite(IRIDIUM_SLEEP_PIN, HIGH);
   delay(1000); // TODO: check if this is long enough for modem to wake up
-  while (unsentMessageLog.numMessages() > 0) {
-    Serial.print(F("Sending messages..."));
-    Serial.println(unsentMessageLog.numMessages());
-    message = "";
-    unsentMessageLog.pop(&message);
-    Serial.println(message);
-    if (message.equals("")) {
-      Serial.println(F("Empty message pulled from message log. Probably an error."));
-      continue;
-    }
+  Serial.print(F("Sending messages..."));
+  Serial.println(*message);
 
-    // send via Iridum modem
-    int signalQualityResult;
-    int signalQuality = -1;
-    signalQualityResult = modem.getSignalQuality(signalQuality);
-    if (signalQualityResult == ISBD_SUCCESS) {
-      Serial.print("Signal quality: ");
-      Serial.println(signalQuality);
-      if (signalQuality >= IRIDIUM_SIGNAL_QUALITY_THRESHOLD ) {
-        Serial.println("Sending message: " + message);
-        Serial.println(F("This might take several minutes."));
-        int sendSBDTextResult;
-        sendSBDTextResult = modem.sendSBDText(message.c_str());
-        if (sendSBDTextResult != ISBD_SUCCESS) {
-          Serial.print(F("sendSBDText failed: error "));
-          Serial.println(sendSBDTextResult);
-        }
-      } else {
-        Serial.println(F("Quality should be 2 or higher to send"));
+  // send via Iridum modem
+  int signalQualityResult;
+  int signalQuality = -1;
+  signalQualityResult = modem.getSignalQuality(signalQuality);
+  if (signalQualityResult == ISBD_SUCCESS) {
+    Serial.print("Signal quality: ");
+    Serial.println(signalQuality);
+    if (signalQuality >= IRIDIUM_SIGNAL_QUALITY_THRESHOLD ) {
+      Serial.println("Sending message: " + *message);
+      Serial.println(F("This might take several minutes."));
+      int sendSBDTextResult;
+      sendSBDTextResult = modem.sendSBDText(((String)*message).c_str());
+      if (sendSBDTextResult != ISBD_SUCCESS) {
+        Serial.print(F("sendSBDText failed: error "));
+        Serial.println(sendSBDTextResult);
       }
     } else {
-      Serial.print(F("SignalQuality failed: error "));
-      Serial.println(signalQualityResult);
+      Serial.println(F("Quality should be 2 or higher to send"));
     }
-
-    if (sentMessageLog.push(&message) != 0) {
-      Serial.println(F("Error sentMessageLog.push()."));
-    }
+  } else {
+    Serial.print(F("SignalQuality failed: error "));
+    Serial.println(signalQualityResult);
   }
-  // put iridium modem back to sleep
-  digitalWrite(IRIDIUM_SLEEP_PIN, LOW);
 }
 
 void sleepCheck() {
@@ -190,6 +174,8 @@ void sleepCheck() {
     digitalWrite(SDCardActivityLEDPin, LOW);
     #endif
     Serial.println(F("sleeping as timed out"));
+    // put iridium modem to sleep
+    digitalWrite(IRIDIUM_SLEEP_PIN, LOW);
     #ifdef WINDOWS_DEV
     USBDevice.detach();
     #else


### PR DESCRIPTION
- Remove `unsentMessageLog`
- Call `sendMessage(String *)` after each message is read from `RelaySerial`
- Move Iridium sleep to `sleepCheck()`
- Remove now-unused `sendMessages()`

CAVEAT: the [`RingBuffer`](/adafruit/ArduinoCore-samd/blob/67dfb93a4a141a8ed76ddab9561100132a5dffe4/cores/arduino/RingBuffer.h#L36) used by the [`Uart` class](/adafruit/ArduinoCore-samd/blob/67dfb93a4a141a8ed76ddab9561100132a5dffe4/cores/arduino/Uart.h#L27) is set to 350 bytes by [`SERIAL_BUFFER_SIZE`](/adafruit/ArduinoCore-samd/blob/67dfb93a4a141a8ed76ddab9561100132a5dffe4/cores/arduino/RingBuffer.h#L32). If messages come in over `RelaySerial` faster than they can be sent then data will be lost.